### PR TITLE
Hazelcast upgraded to 5.0-BETA-2

### DIFF
--- a/cryptocurrency-sentiment-analysis/pom.xml
+++ b/cryptocurrency-sentiment-analysis/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <name>Twitter Cryptocurrency Sentiment Analysis</name>

--- a/flight-telemetry/pom.xml
+++ b/flight-telemetry/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <name>ADB-S Flight Telemetry Stream Processing Demo</name>

--- a/h2o-breast-cancer-classification/pom.xml
+++ b/h2o-breast-cancer-classification/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/markov-chain-generator/pom.xml
+++ b/markov-chain-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <name>Markov Chain Generator</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hazelcast.demos</groupId>
     <artifactId>hazelcast-demos</artifactId>
-    <version>5.0-SNAPSHOT</version>
+    <version>5.0-BETA-2</version>
     <packaging>pom</packaging>
     <name>Hazelcast Jet Demo Applications</name>
 
@@ -46,7 +46,7 @@
 
     <properties>
         <jdk.version>1.8</jdk.version>
-        <hazelcast.version>5.0-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>5.0-BETA-2</hazelcast.version>
         <maven.compiler.plugin.version>2.5.1</maven.compiler.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/realtime-image-recognition/pom.xml
+++ b/realtime-image-recognition/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <name>Real-time Image Recognition Demo</name>

--- a/realtime-trade-monitor/jet-server/pom.xml
+++ b/realtime-trade-monitor/jet-server/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>realtime-trade-monitor</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <build>
@@ -56,6 +56,17 @@
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-kafka</artifactId>
+            <version>${hazelcast.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-sql</artifactId>
+            <version>${hazelcast.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast.jet</groupId>
+            <artifactId>hazelcast-jet-csv</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
 

--- a/realtime-trade-monitor/jet-server/src/main/resources/hazelcast.yaml
+++ b/realtime-trade-monitor/jet-server/src/main/resources/hazelcast.yaml
@@ -1,5 +1,5 @@
 hazelcast:
-  cluster-name: jet
+  cluster-name: dev
   jet:
     enabled: true
     resource-upload-enabled: true
@@ -28,6 +28,9 @@ hazelcast:
         - type: HASH
           attributes:
             - "symbol"
+        - type: SORTED
+          attributes:
+            - "timestamp"
     symbols:
       in-memory-format: BINARY
     query1_Results:

--- a/realtime-trade-monitor/pom.xml
+++ b/realtime-trade-monitor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hazelcast-demos</artifactId>
         <groupId>com.hazelcast.demos</groupId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,7 +22,7 @@
 
     <properties>
         <jdk.version>1.8</jdk.version>
-        <hazelcast.version>5.0-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>5.0-BETA-2</hazelcast.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>

--- a/realtime-trade-monitor/trade-producer/pom.xml
+++ b/realtime-trade-monitor/trade-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>realtime-trade-monitor</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <dependencies>

--- a/realtime-trade-monitor/trade-queries/pom.xml
+++ b/realtime-trade-monitor/trade-queries/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>realtime-trade-monitor</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <dependencies>

--- a/realtime-trade-monitor/trade-queries/src/main/resources/hazelcast-client.yaml
+++ b/realtime-trade-monitor/trade-queries/src/main/resources/hazelcast-client.yaml
@@ -1,5 +1,5 @@
 hazelcast-client:
-  cluster-name: jet
+  cluster-name: dev
   instance-name: query-client
   network:
     cluster-members:

--- a/realtime-trade-monitor/webapp/pom.xml
+++ b/realtime-trade-monitor/webapp/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>realtime-trade-monitor</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <properties>

--- a/realtime-trade-monitor/webapp/src/main/resources/hazelcast-client.yaml
+++ b/realtime-trade-monitor/webapp/src/main/resources/hazelcast-client.yaml
@@ -1,5 +1,5 @@
 hazelcast-client:
-  cluster-name: jet
+  cluster-name: dev
   instance-name: query-client
   network:
     cluster-members:

--- a/road-traffic-predictor/pom.xml
+++ b/road-traffic-predictor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <artifactId>road-traffic-predictor</artifactId>

--- a/tensorflow/pom.xml
+++ b/tensorflow/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <properties>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hazelcast-demos</artifactId>
         <groupId>com.hazelcast.demos</groupId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tests/tools/pom.xml
+++ b/tests/tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tests</artifactId>
         <groupId>com.hazelcast.demos</groupId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tests/tools/qe-data-observer/pom.xml
+++ b/tests/tools/qe-data-observer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tools</artifactId>
         <groupId>com.hazelcast.demos</groupId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <artifactId>qe-data-observer</artifactId>

--- a/tests/tools/qe-kafka-manager/pom.xml
+++ b/tests/tools/qe-kafka-manager/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tools</artifactId>
         <groupId>com.hazelcast.demos</groupId>
-        <version>5.0-SNAPSHOT</version>
+        <version>5.0-BETA-2</version>
     </parent>
 
     <artifactId>qe-kafka-manager</artifactId>


### PR DESCRIPTION
- Hazelcast Server upgraded to 5.0-BETA-2 for all demos
- For realtime-trade-analysis, the server component upgraded to include SQL module and CSV file integration for ad-hoc queries; The cluster name changed to dev to comply with Hz 5 defaults.