### PR TITLE
Verify trades demo on cloud

### DIFF
--- a/cryptocurrency-sentiment-analysis/pom.xml
+++ b/cryptocurrency-sentiment-analysis/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <name>Twitter Cryptocurrency Sentiment Analysis</name>

--- a/flight-telemetry/pom.xml
+++ b/flight-telemetry/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <name>ADB-S Flight Telemetry Stream Processing Demo</name>

--- a/h2o-breast-cancer-classification/pom.xml
+++ b/h2o-breast-cancer-classification/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/markov-chain-generator/pom.xml
+++ b/markov-chain-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <name>Markov Chain Generator</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hazelcast.demos</groupId>
     <artifactId>hazelcast-demos</artifactId>
-    <version>5.0-BETA-2</version>
+    <version>5.0</version>
     <packaging>pom</packaging>
     <name>Hazelcast Jet Demo Applications</name>
 
@@ -46,7 +46,7 @@
 
     <properties>
         <jdk.version>1.8</jdk.version>
-        <hazelcast.version>5.0-BETA-2</hazelcast.version>
+        <hazelcast.version>5.0</hazelcast.version>
         <maven.compiler.plugin.version>2.5.1</maven.compiler.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/realtime-image-recognition/pom.xml
+++ b/realtime-image-recognition/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <name>Real-time Image Recognition Demo</name>

--- a/realtime-trade-monitor/README.md
+++ b/realtime-trade-monitor/README.md
@@ -24,14 +24,14 @@ kafka-topics --create --replication-factor 1 --partitions 4 --topic trades --zoo
 2. Start the Kafka producer
 
 ```
-java -jar trade-producer/target/trade-producer-5.0-SNAPSHOT.jar <bootstrap servers> <trades per sec>
+java -jar trade-producer/target/trade-producer-5.0.jar <bootstrap servers> <trades per sec>
 ```
 
 3. Start the Jet cluster. To configure cluster members you can edit 
 `hazelcast.yaml` in the `jet-server/src/main/resources` folder.
 
 ```
-java -jar jet-server/target/jet-server-5.0-SNAPSHOT.jar
+java -jar jet-server/target/jet-server-5.0.jar
 ```
 
 4. Run the queries
@@ -40,17 +40,17 @@ The cluster connection can be configured inside the `hazelcast-client.yaml` file
 
 * Load static data into map: (Stock names)
 ```
-java -jar trade-queries/target/trade-queries-5.0-SNAPSHOT.jar load-symbols
+java -jar trade-queries/target/trade-queries-5.0.jar load-symbols
 ```
 
 * Ingest trades from Kafka
 
 ```
-java -jar trade-queries/target/trade-queries-5.0-SNAPSHOT.jar ingest-trades <bootstrap servers>
+java -jar trade-queries/target/trade-queries-5.0.jar ingest-trades <bootstrap servers>
 ```
 * Aggregate trades by symbol
 ```
-java -jar trade-queries/target/trade-queries-5.0-SNAPSHOT.jar aggregate-query <bootstrap servers>
+java -jar trade-queries/target/trade-queries-5.0.jar aggregate-query <bootstrap servers>
 ```
 
 5. Start the front end
@@ -58,7 +58,72 @@ java -jar trade-queries/target/trade-queries-5.0-SNAPSHOT.jar aggregate-query <b
 The cluster connection can be configured inside the `hazelcast-client.yaml` file.
 
 ```
-java -jar webapp/target/webapp-5.0-SNAPSHOT.jar 
+java -jar webapp/target/webapp-5.0.jar 
+```
+
+Browse to localhost:9000 to see the dashboard.
+
+## How to run using Hazelcast Cloud:
+
+1. Create Enterprise Hazelcast cluster in https://cloud.hazelcast.com/
+
+2. Open client configuration window on the cluster details page and grab cluster id and discovery token. 
+
+3. Modify Hazelcast client configs `trade-queries/src/main/resources/hazelcast-client.yaml` and
+   `webapp/src/main/resources/hazelcast-client.yaml` 
+   by putting there cluster id and discovery token from previous step. Minimal working config example:
+```
+hazelcast-client:
+  cluster-name: <CLUSTER_NAME>
+  instance-name: query-client
+  properties:
+    hazelcast.client.cloud.url: "https://uat.hazelcast.cloud" #Optional, if env is not default
+    hazelcast.client.cloud.discovery.token: "<CLUSTER_TOKEN>"
+```    
+
+4. We need to have Kafka cluster that is reachable by Hazalcast Cloud nodes. For demo purposes, the easiest way is
+   to create the simplest Kafka cluster at https://confluent.cloud with defaults.
+
+5. Create topic `trades`. If you use https://confluent.cloud go to Topics section in the UI.
+
+
+6. Put all kafka consumer/producer properties in `trade-producer/src/main/resources/kafka.properties` and
+   `trade-queries/src/main/resources/kafka.properties`. If you use https://confluent.cloud you can find them in
+   Data Integration - Client - New Client section.
+
+8. Build the project
+
+```
+mvn package
+```
+
+8. Start the Kafka producer
+
+```
+java -jar trade-producer/target/trade-producer-5.0.jar "" <trades per sec>
+```
+
+9. Run the queries
+
+* Load static data into map: (Stock names)
+```
+java -jar trade-queries/target/trade-queries-5.0.jar load-symbols
+```
+
+* Ingest trades from Kafka
+
+```
+java -jar trade-queries/target/trade-queries-5.0.jar ingest-trades ""
+```
+* Aggregate trades by symbol
+```
+java -jar trade-queries/target/trade-queries-5.0.jar aggregate-query ""
+```
+
+5. Start the front end
+
+```
+java -jar webapp/target/webapp-5.0.jar 
 ```
 
 Browse to localhost:9000 to see the dashboard.

--- a/realtime-trade-monitor/jet-server/pom.xml
+++ b/realtime-trade-monitor/jet-server/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>realtime-trade-monitor</artifactId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <build>

--- a/realtime-trade-monitor/pom.xml
+++ b/realtime-trade-monitor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hazelcast-demos</artifactId>
         <groupId>com.hazelcast.demos</groupId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,7 +22,7 @@
 
     <properties>
         <jdk.version>1.8</jdk.version>
-        <hazelcast.version>5.0-BETA-2</hazelcast.version>
+        <hazelcast.version>5.0</hazelcast.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>

--- a/realtime-trade-monitor/trade-producer/pom.xml
+++ b/realtime-trade-monitor/trade-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>realtime-trade-monitor</artifactId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <dependencies>

--- a/realtime-trade-monitor/trade-producer/src/main/java/TradeProducer.java
+++ b/realtime-trade-monitor/trade-producer/src/main/java/TradeProducer.java
@@ -29,7 +29,7 @@ public class TradeProducer {
 
     private long emitSchedule;
 
-    public static void main(String[] args) throws InterruptedException {
+    public static void main(String[] args) throws InterruptedException, IOException {
         if (args.length == 0) {
             System.out.println("TradeProducer <bootstrap servers> <rate>");
             System.exit(1);
@@ -37,7 +37,10 @@ public class TradeProducer {
         String servers = args[0];
         int rate = Integer.parseInt(args[1]);
         Properties props = new Properties();
-        props.setProperty("bootstrap.servers", servers);
+        props.load(TradeProducer.class.getResourceAsStream("kafka.properties"));
+        if (!servers.isEmpty()) {
+            props.setProperty("bootstrap.servers", servers);
+        }
         props.setProperty("key.serializer", StringSerializer.class.getName());
         props.setProperty("value.serializer", StringSerializer.class.getName());
 

--- a/realtime-trade-monitor/trade-queries/pom.xml
+++ b/realtime-trade-monitor/trade-queries/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>realtime-trade-monitor</artifactId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <dependencies>

--- a/realtime-trade-monitor/trade-queries/src/main/resources/hazelcast-client.yaml
+++ b/realtime-trade-monitor/trade-queries/src/main/resources/hazelcast-client.yaml
@@ -1,6 +1,11 @@
 hazelcast-client:
   cluster-name: dev
   instance-name: query-client
+  # For local clusters
   network:
     cluster-members:
       - 127.0.0.1
+# For Hazelcast Cloud
+# properties:
+#   hazelcast.client.cloud.url: "https://uat.hazelcast.cloud" #Optional, if env is not default
+#   hazelcast.client.cloud.discovery.token: "TOKEN"

--- a/realtime-trade-monitor/webapp/pom.xml
+++ b/realtime-trade-monitor/webapp/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>realtime-trade-monitor</artifactId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <properties>

--- a/realtime-trade-monitor/webapp/src/main/resources/hazelcast-client.yaml
+++ b/realtime-trade-monitor/webapp/src/main/resources/hazelcast-client.yaml
@@ -1,6 +1,11 @@
 hazelcast-client:
   cluster-name: dev
   instance-name: query-client
+# For local clusters
   network:
     cluster-members:
       - 127.0.0.1
+# For Hazelcast Cloud
+# properties:
+#   hazelcast.client.cloud.url: "https://uat.hazelcast.cloud" #Optional, if env is not default
+#   hazelcast.client.cloud.discovery.token: "TOKEN"

--- a/road-traffic-predictor/pom.xml
+++ b/road-traffic-predictor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <artifactId>road-traffic-predictor</artifactId>

--- a/tensorflow/pom.xml
+++ b/tensorflow/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.hazelcast.demos</groupId>
         <artifactId>hazelcast-demos</artifactId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <properties>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hazelcast-demos</artifactId>
         <groupId>com.hazelcast.demos</groupId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tests/tools/pom.xml
+++ b/tests/tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tests</artifactId>
         <groupId>com.hazelcast.demos</groupId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/tests/tools/qe-data-observer/pom.xml
+++ b/tests/tools/qe-data-observer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tools</artifactId>
         <groupId>com.hazelcast.demos</groupId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <artifactId>qe-data-observer</artifactId>

--- a/tests/tools/qe-kafka-manager/pom.xml
+++ b/tests/tools/qe-kafka-manager/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tools</artifactId>
         <groupId>com.hazelcast.demos</groupId>
-        <version>5.0-BETA-2</version>
+        <version>5.0</version>
     </parent>
 
     <artifactId>qe-kafka-manager</artifactId>


### PR DESCRIPTION
This PR does the following:
1. Bumps Hazelcast version to 5.0.
2. Adds support for setting all Kafka properties in one file for `realtime-trade-monitor` demo app. Needed for the case when Kafka cluster is running externally. 
3. Adds readme section for running `realtime-trade-monitor`  demo using Hazelcast Cloud.